### PR TITLE
chore: release fp-library v0.16.1 / fp-macros v0.7.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,29 @@ nix develop
 
 This will provide a shell with the correct Rust version and dependencies.
 
+### Rebuilding the Dev Shell
+
+nix-direnv caches the dev shell for performance. If `devenv/flake.nix` or
+`devenv/flake.lock` changes (e.g., after pulling new commits that update
+dependencies or add tools), the cache may be stale and new tools will be
+missing from your PATH.
+
+**Signs the cache is stale:**
+
+- A tool listed in `devenv/flake.nix` is not found (e.g., `lychee: command not found`).
+- `direnv export` output says "Using cached dev shell" after you know the flake changed.
+- A `just` recipe fails with a missing command even though the tool is in the flake.
+
+**To rebuild:**
+
+```sh
+# Remove the cached shell and reload
+rm -f .direnv/flake-profile* .direnv/nix-direnv.*
+direnv allow
+```
+
+If using `nix develop` directly instead of direnv, exit and re-enter the shell.
+
 ## Building and Testing
 
 All commands are run via [just](https://github.com/casey/just) recipes defined in the project's `justfile`. Never run `cargo` directly; the `justfile` handles Nix environment setup automatically.
@@ -42,6 +65,51 @@ just clean   # Remove build artifacts and test cache
 ```
 
 Run `just --list` to see all available recipes.
+
+## Snapshot Tests
+
+The HM type signature generation system uses [insta](https://insta.rs/) snapshot tests to guard against regressions. If you change the signature rendering code in `fp-macros`, snapshots may need updating.
+
+```sh
+# Run snapshot tests to see if any changed
+just test -p fp-macros --lib -- snapshot
+
+# Review and accept/reject changed snapshots interactively
+cargo insta review
+
+# Accept all changed snapshots without review
+cargo insta accept
+```
+
+You can also review snapshots manually by running the tests with `INSTA_UPDATE=new` and inspecting the `.snap.new` files in `fp-macros/src/documentation/snapshots/`.
+
+## Compile-Fail Tests (trybuild)
+
+Both `fp-macros` and `fp-library` use [trybuild](https://github.com/dtolnay/trybuild)
+for compile-fail tests. These are `.rs` files in `tests/ui/` that must fail to compile,
+with expected compiler output stored in matching `.stderr` golden files.
+
+If your changes alter error messages (e.g., changing a proc macro's error output,
+renaming types, or moving modules), the `.stderr` files need updating.
+
+**Signs a trybuild test is stale:**
+
+- Test output shows a diff between expected and actual compiler stderr.
+- The diff contains changed file paths, line numbers, or error wording.
+
+**To update:**
+
+```sh
+# Overwrite all stale .stderr files with current compiler output
+TRYBUILD=overwrite just test
+
+# Or update only a specific crate's tests
+TRYBUILD=overwrite just test -p fp-macros
+TRYBUILD=overwrite just test -p fp-library
+```
+
+Always review the updated `.stderr` files before committing to ensure the new
+error messages are correct and intentional.
 
 ## Project Structure
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "fp-library"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "criterion",
  "fp-macros",
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "fp-macros"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "insta",
  "proc-macro-warning",

--- a/devenv/flake.nix
+++ b/devenv/flake.nix
@@ -156,6 +156,7 @@
                 pkgs.pkg-config
                 pkgs.cargo-deny
                 pkgs.cargo-edit
+                pkgs.cargo-insta
                 pkgs.bacon
                 pkgs.rust-analyzer
                 pkgs.gh

--- a/fp-library/CHANGELOG.md
+++ b/fp-library/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-04-15
+
+### Added
+
+- **`docs` module**: 19 documentation submodules (`docs::hkt`, `docs::features`, `docs::zero_cost`, etc.) generated from the markdown files in `fp-library/docs/`. Cross-document links are rewritten as rustdoc intra-doc links via the new `doc_include!` macro, making them work in rendered docs (docs.rs and local `cargo doc` builds).
+- **`cargo-insta`** added to the Nix dev shell for snapshot test management.
+
+### Changed
+
+- **Crate root documentation**: Replaced inline doc includes (8 full documents) with concise "How it Works" summaries and a Documentation links section pointing to the `docs` module subpages.
+- **`functions` module documentation**: Updated to describe the module as the primary API for dispatch functions with brand inference, with examples for both inference and explicit variants.
+
 ## [0.16.0] - 2026-04-14
 
 ### Added

--- a/fp-library/Cargo.toml
+++ b/fp-library/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fp-library"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 description = "A functional programming library for Rust featuring your favourite higher-kinded types and type classes."
 readme = "../README.md"

--- a/fp-library/docs/coyoneda.md
+++ b/fp-library/docs/coyoneda.md
@@ -130,7 +130,7 @@ A fundamentally different design. Instead of hiding the intermediate type
 parameter. Functions are composed at the type level (compile time), not via
 dynamic dispatch.
 
-```rust
+```rust,ignore
 struct CoyonedaExplicit<'a, F, B, A, Func: Fn(B) -> A = Box<dyn Fn(B) -> A + 'a>> {
     fb: F::Of<'a, B>,
     func: Func,
@@ -226,7 +226,7 @@ recursion per chained `map`. Three mitigations:
 `ArcCoyoneda` uses associated type bounds on the `Kind` trait (stable
 since Rust 1.79) to let the compiler auto-derive `Send`/`Sync`:
 
-```rust
+```rust,ignore
 struct ArcCoyonedaBase<'a, F, A: 'a>
 where
     F: Kind<Of<'a, A>: Send + Sync> + 'a,

--- a/fp-library/docs/impl-trait-vs-named-generics.md
+++ b/fp-library/docs/impl-trait-vs-named-generics.md
@@ -6,7 +6,7 @@ This document describes when to use `impl Trait` vs named generic type parameter
 
 In Rust, `impl Trait` in argument position is syntactic sugar for a named generic:
 
-```rust
+```rust,ignore
 fn map<A, B>(f: impl Fn(A) -> B, fa: Option<A>) -> Option<B>
 // desugars to:
 fn map<A, B, Func: Fn(A) -> B>(f: Func, fa: Option<A>) -> Option<B>
@@ -16,7 +16,7 @@ Both are universally quantified (the caller chooses the concrete type). The diff
 
 This applies to any trait bound used as a function parameter, not just `Fn`/`FnMut`/`FnOnce`:
 
-```rust
+```rust,ignore
 fn print(x: impl Display)
 fn sum(iter: impl Iterator<Item = i32>) -> i32
 fn read_from(source: impl Read) -> Vec<u8>
@@ -43,7 +43,7 @@ The `impl Fn(A) -> B` encoding mirrors this: the function parameter is not a sep
 
 Use `impl Trait` when the type only appears once and the caller has no reason to name it:
 
-```rust
+```rust,ignore
 // The closure type is an implementation detail
 fn map<'a, A: 'a, B: 'a>(
     f: impl Fn(A) -> B + 'a,
@@ -65,20 +65,20 @@ Use a named generic when the type serves a structural role in the signature.
 
 #### The type appears in multiple positions
 
-```rust
+```rust,ignore
 fn combine<T: Semigroup>(a: T, b: T) -> T
 ```
 
 With `impl Trait`, each occurrence introduces an **independent** anonymous type parameter:
 
-```rust
+```rust,ignore
 // BAD: a and b can be DIFFERENT types
 fn combine(a: impl Semigroup, b: impl Semigroup) -> impl Semigroup
 ```
 
 #### The return type depends on the input type
 
-```rust
+```rust,ignore
 fn identity<T>(x: T) -> T       // caller gets the same type back
 fn identity(x: impl Any) -> impl Any  // caller gets an opaque type
 ```
@@ -89,7 +89,7 @@ The named generic preserves the connection between input and output.
 
 When a where clause relates the type to other parameters, it must be named:
 
-```rust
+```rust,ignore
 fn apply<'a, A: 'a, B: 'a, F>(f: F, xs: Vec<A>) -> Vec<B>
 where
     F: Fn(A) -> B + Clone + Send + 'a,
@@ -97,7 +97,7 @@ where
 
 If the bounds are simple enough to fit inline, `impl Trait` still works:
 
-```rust
+```rust,ignore
 fn map<'a, A: 'a, B: 'a>(f: impl Fn(A) -> B + 'a, fa: ...) -> ...
 ```
 
@@ -107,7 +107,7 @@ Use judgment based on readability.
 
 If callers must specify the type explicitly, it must be named:
 
-```rust
+```rust,ignore
 let x = default::<u32>();  // T must be nameable
 ```
 

--- a/fp-library/docs/lifetime-ablation-experiment.md
+++ b/fp-library/docs/lifetime-ablation-experiment.md
@@ -81,7 +81,7 @@ When a user provides a closure to `map` or `bind`, that closure often captures v
 
 This effectively disables standard FP patterns like:
 
-```rust
+```rust,ignore
 let x = 10;
 let res = list.map(|y| x + y); // Error: closure captures `x` by reference, not static.
 ```

--- a/fp-library/docs/limitations-and-workarounds.md
+++ b/fp-library/docs/limitations-and-workarounds.md
@@ -81,7 +81,7 @@ Several types (`RcCoyoneda`, `ArcCoyoneda`) cannot implement type class traits a
 
 For example, `RcCoyoneda::lift` requires `F::Of<'a, A>: Clone` because the base layer must be clonable for `lower_ref` to work. But the `Pointed` trait's `pure` method has no way to express this:
 
-```rust
+```rust,ignore
 // Pointed::pure signature - no Clone bound on the return type's contents
 fn pure<'a, A: 'a>(value: A) -> Self::Of<'a, A>;
 ```
@@ -102,7 +102,7 @@ For `ArcCoyoneda`, the problem is compounded: `Functor::map` also cannot be impl
 
 All affected operations are available as inherent methods with the necessary bounds stated explicitly:
 
-```rust
+```rust,ignore
 // RcCoyoneda - inherent pure with Clone bound
 impl<'a, F, A: 'a> RcCoyoneda<'a, F, A> {
 	pub fn pure(value: A) -> Self
@@ -127,7 +127,7 @@ Rust's trait system does not support conditional bounds on associated types. The
 
 `Lazy::evaluate()` returns `&A` (a reference to the cached value), not an owned `A`. The standard `Functor` trait expects `map` to consume an owned `A`:
 
-```rust
+```rust,ignore
 fn map<'a, A: 'a, B: 'a>(f: impl Fn(A) -> B + 'a, fa: Self::Of<'a, A>) -> Self::Of<'a, B>;
 ```
 
@@ -184,7 +184,7 @@ This limitation stems from the design of the `Arrow` and `CloneFn` traits, which
 1.  **`CloneFn::new` accepts non-`Send` functions:**
     The `CloneFn` trait defines its constructor as:
 
-    ```rust
+    ```rust,ignore
     fn new<'a, A, B>(f: impl 'a + Fn(A) -> B) -> ...
     ```
 
@@ -192,7 +192,7 @@ This limitation stems from the design of the `Arrow` and `CloneFn` traits, which
 
 2.  **`Function` Trait Type Constraints:**
     The `Arrow` trait enforces strict type equality on its associated type:
-    ```rust
+    ```rust,ignore
     type Of<'a, A, B>: Deref<Target = dyn 'a + Fn(A) -> B>;
     ```
     This prevents `ArcFnBrand` from defining its inner type as `Arc<dyn Fn(...) + Send + Sync>`, because `dyn Fn + Send + Sync` is a different type than `dyn Fn`.

--- a/fp-library/docs/optics-analysis.md
+++ b/fp-library/docs/optics-analysis.md
@@ -23,7 +23,7 @@ Rust cannot express rank-2 types or universally quantified type aliases. The lib
 
 1. **Concrete structs** (`Lens`, `Prism`, `Iso`, etc.) that hold the reified internal representation - equivalent to PureScript's `ALens`/`APrism`/`AnIso` types.
 2. **Optic traits** defining profunctor evaluation:
-   ```rust
+   ```rust,ignore
    pub trait Optic<'a, P: Profunctor, S, T, A, B> {
        fn evaluate(&self, pab: P::Of<'a, A, B>) -> P::Of<'a, S, T>;
    }
@@ -228,7 +228,7 @@ Rust cannot express rank-2 types or universally quantified type aliases. The lib
 
 PureScript establishes an optic lattice through profunctor class inheritance. Rust models this via manual trait implementations on concrete structs and on `Composed`.
 
-```
+```text
             Iso
           / | \  \
       Lens Prism Grate  Review
@@ -416,7 +416,7 @@ The first group (`IsoOptic` through `TraversalOptic`) places the profunctor at m
 
 The rationale is sound (trait-level for fixed brands, method-level for universal quantification), but the observable effect is inconsistent downstream bounds:
 
-```rust
+```rust,ignore
 // Getter: no brand in trait position
 fn optics_view<PointerBrand, O, S, A>(optic: &O, s: S) -> A
 where O: GetterOptic<'a, S, A> { ... }
@@ -497,7 +497,7 @@ In PureScript, `re` reverses an optic: `re t = unwrap (t (Re identity))`. The Ru
 
 #### 5.2 The `ReversedOptic` Struct
 
-```rust
+```rust,ignore
 pub struct ReversedOptic<'a, PointerBrand, S, T, A, B, O>
 where
     PointerBrand: UnsizedCoercible,
@@ -513,7 +513,7 @@ where
 
 And a free function:
 
-```rust
+```rust,ignore
 pub fn reverse<'a, PointerBrand, S, T, A, B, O>(
     optic: O,
 ) -> ReversedOptic<'a, PointerBrand, S, T, A, B, O>
@@ -534,7 +534,7 @@ Three trait implementations are possible. Each follows the pattern: construct `R
 
 ##### 5.3.1 `ReviewOptic` - reversing any optic >= `AffineTraversal`
 
-```rust
+```rust,ignore
 impl<'a, PointerBrand, S, T, A, B, O> ReviewOptic<'a, B, A, T, S>
     for ReversedOptic<'a, PointerBrand, S, T, A, B, O>
 where
@@ -565,7 +565,7 @@ where
 
 ##### 5.3.2 `GetterOptic` - reversing prism-like optics
 
-```rust
+```rust,ignore
 impl<'a, PointerBrand, S, A, O> GetterOptic<'a, A, S>
     for ReversedOptic<'a, PointerBrand, S, S, A, A, O>
 where
@@ -599,7 +599,7 @@ where
 
 ##### 5.3.3 `FoldOptic` - same as `GetterOptic` but with `R: Monoid + Clone`
 
-```rust
+```rust,ignore
 impl<'a, PointerBrand, S, A, O> FoldOptic<'a, A, S>
     for ReversedOptic<'a, PointerBrand, S, S, A, A, O>
 where
@@ -643,7 +643,7 @@ where
 
 Add to `reverse.rs` imports:
 
-```rust
+```rust,ignore
 use crate::{
     classes::optics::{
         AffineTraversalOptic, FoldOptic, GetterOptic, PrismOptic, ReviewOptic,

--- a/fp-library/docs/profunctor-analysis.md
+++ b/fp-library/docs/profunctor-analysis.md
@@ -138,7 +138,7 @@ PureScript renamed `lmap` to `lcmap` to avoid conflict with `Data.Functor.Contra
 
 All profunctor free functions consistently use `Brand` for the profunctor type parameter:
 
-```rust
+```rust,ignore
 pub fn dimap<'a, Brand: Profunctor, ...>(...) { ... }
 pub fn first<'a, Brand: Strong, ...>(...) { ... }
 pub fn closed<'a, Brand: Closed<FunctionBrand>, FunctionBrand: LiftFn, ...>(...) { ... }

--- a/fp-library/src/docs.rs
+++ b/fp-library/src/docs.rs
@@ -1,0 +1,27 @@
+#![allow(rustdoc::invalid_rust_codeblocks)]
+//! Design documentation for fp-library.
+//!
+//! Each submodule contains one design document from the `docs/` directory,
+//! with cross-document links rewritten as rustdoc intra-doc links. This
+//! makes links between documents work in rendered documentation (docs.rs
+//! and local `cargo doc` builds).
+
+pub mod architecture;
+pub mod benchmarking;
+pub mod brand_inference;
+pub mod coyoneda;
+pub mod dispatch;
+pub mod features;
+pub mod hkt;
+pub mod impl_trait_vs_named_generics;
+pub mod lazy_evaluation;
+pub mod lifetime_ablation_experiment;
+pub mod limitations_and_workarounds;
+pub mod optics_analysis;
+pub mod parallelism;
+pub mod pointer_abstraction;
+pub mod profunctor_analysis;
+pub mod project_structure;
+pub mod release_process;
+pub mod std_coverage_checklist;
+pub mod zero_cost;

--- a/fp-library/src/docs/architecture.rs
+++ b/fp-library/src/docs/architecture.rs
@@ -1,0 +1,1 @@
+#![doc = fp_macros::doc_include!("docs/architecture.md")]

--- a/fp-library/src/docs/benchmarking.rs
+++ b/fp-library/src/docs/benchmarking.rs
@@ -1,0 +1,1 @@
+#![doc = fp_macros::doc_include!("docs/benchmarking.md")]

--- a/fp-library/src/docs/brand_inference.rs
+++ b/fp-library/src/docs/brand_inference.rs
@@ -1,0 +1,1 @@
+#![doc = fp_macros::doc_include!("docs/brand-inference.md")]

--- a/fp-library/src/docs/coyoneda.rs
+++ b/fp-library/src/docs/coyoneda.rs
@@ -1,0 +1,1 @@
+#![doc = fp_macros::doc_include!("docs/coyoneda.md")]

--- a/fp-library/src/docs/dispatch.rs
+++ b/fp-library/src/docs/dispatch.rs
@@ -1,0 +1,1 @@
+#![doc = fp_macros::doc_include!("docs/dispatch.md")]

--- a/fp-library/src/docs/features.rs
+++ b/fp-library/src/docs/features.rs
@@ -1,0 +1,1 @@
+#![doc = fp_macros::doc_include!("docs/features.md")]

--- a/fp-library/src/docs/hkt.rs
+++ b/fp-library/src/docs/hkt.rs
@@ -1,0 +1,1 @@
+#![doc = fp_macros::doc_include!("docs/hkt.md")]

--- a/fp-library/src/docs/impl_trait_vs_named_generics.rs
+++ b/fp-library/src/docs/impl_trait_vs_named_generics.rs
@@ -1,0 +1,1 @@
+#![doc = fp_macros::doc_include!("docs/impl-trait-vs-named-generics.md")]

--- a/fp-library/src/docs/lazy_evaluation.rs
+++ b/fp-library/src/docs/lazy_evaluation.rs
@@ -1,0 +1,1 @@
+#![doc = fp_macros::doc_include!("docs/lazy-evaluation.md")]

--- a/fp-library/src/docs/lifetime_ablation_experiment.rs
+++ b/fp-library/src/docs/lifetime_ablation_experiment.rs
@@ -1,0 +1,1 @@
+#![doc = fp_macros::doc_include!("docs/lifetime-ablation-experiment.md")]

--- a/fp-library/src/docs/limitations_and_workarounds.rs
+++ b/fp-library/src/docs/limitations_and_workarounds.rs
@@ -1,0 +1,1 @@
+#![doc = fp_macros::doc_include!("docs/limitations-and-workarounds.md")]

--- a/fp-library/src/docs/optics_analysis.rs
+++ b/fp-library/src/docs/optics_analysis.rs
@@ -1,0 +1,1 @@
+#![doc = fp_macros::doc_include!("docs/optics-analysis.md")]

--- a/fp-library/src/docs/parallelism.rs
+++ b/fp-library/src/docs/parallelism.rs
@@ -1,0 +1,1 @@
+#![doc = fp_macros::doc_include!("docs/parallelism.md")]

--- a/fp-library/src/docs/pointer_abstraction.rs
+++ b/fp-library/src/docs/pointer_abstraction.rs
@@ -1,0 +1,1 @@
+#![doc = fp_macros::doc_include!("docs/pointer-abstraction.md")]

--- a/fp-library/src/docs/profunctor_analysis.rs
+++ b/fp-library/src/docs/profunctor_analysis.rs
@@ -1,0 +1,1 @@
+#![doc = fp_macros::doc_include!("docs/profunctor-analysis.md")]

--- a/fp-library/src/docs/project_structure.rs
+++ b/fp-library/src/docs/project_structure.rs
@@ -1,0 +1,1 @@
+#![doc = fp_macros::doc_include!("docs/project-structure.md")]

--- a/fp-library/src/docs/release_process.rs
+++ b/fp-library/src/docs/release_process.rs
@@ -1,0 +1,1 @@
+#![doc = fp_macros::doc_include!("docs/release-process.md")]

--- a/fp-library/src/docs/std_coverage_checklist.rs
+++ b/fp-library/src/docs/std_coverage_checklist.rs
@@ -1,0 +1,1 @@
+#![doc = fp_macros::doc_include!("docs/std-coverage-checklist.md")]

--- a/fp-library/src/docs/zero_cost.rs
+++ b/fp-library/src/docs/zero_cost.rs
@@ -1,0 +1,1 @@
+#![doc = fp_macros::doc_include!("docs/zero-cost.md")]

--- a/fp-library/src/functions.rs
+++ b/fp-library/src/functions.rs
@@ -1,27 +1,34 @@
-//! Contains generic, helper free functions and re-exports of free versions
-//! of type class functions.
+//! The primary API for calling type class operations as free functions.
 //!
-//! This module provides a collection of utility functions commonly found in functional programming,
-//! such as function composition, constant functions, and identity functions. It also re-exports
-//! free function versions of methods defined in various type classes (traits) for convenience.
+//! This module re-exports inference-enabled dispatch functions from
+//! [`dispatch`](crate::dispatch). These functions automatically infer the
+//! Brand type parameter from the container argument, so callers do not need
+//! a turbofish annotation:
 //!
-//! ### Examples
+//! ```
+//! use fp_library::functions::*;
+//!
+//! // Brand is inferred as VecBrand from the Vec argument.
+//! let result = map(|x: i32| x + 1, vec![1, 2, 3]);
+//! assert_eq!(result, vec![2, 3, 4]);
+//! ```
+//!
+//! For cases where Brand inference is ambiguous (e.g., generic contexts),
+//! the [`explicit`] submodule provides versions that require a Brand
+//! turbofish:
 //!
 //! ```
 //! use fp_library::{
 //! 	brands::*,
-//! 	functions::{
-//! 		compose,
-//! 		explicit::*,
-//! 	},
+//! 	functions::explicit::*,
 //! };
 //!
-//! let f = |x: i32| x + 1;
-//! let g = |x: i32| x * 2;
-//! let h = compose(f, g);
-//!
-//! assert_eq!(map::<OptionBrand, _, _, _, _>(h, Some(5)), Some(11));
+//! let result = map::<VecBrand, _, _, _, _>(|x: i32| x + 1, vec![1, 2, 3]);
+//! assert_eq!(result, vec![2, 3, 4]);
 //! ```
+//!
+//! The module also defines standalone utility functions such as [`compose`],
+//! [`constant`], [`flip`], [`identity`], and [`on`].
 
 use fp_macros::*;
 

--- a/fp-library/src/lib.rs
+++ b/fp-library/src/lib.rs
@@ -72,16 +72,59 @@
 //! });
 //! assert_eq!(result, vec![11, 21, 12, 22]);
 //! ```
-#![doc = fp_macros::doc_include!("docs/features.md")]
+//! ## Features
+//!
+//! For a detailed breakdown of all features, type class hierarchies,
+//! data types, and macros, see the [Features documentation][crate::docs::features].
 //!
 //! ## How it Works
-#![doc = fp_macros::doc_include!("docs/hkt.md")]
-#![doc = fp_macros::doc_include!("docs/brand-inference.md")]
-#![doc = fp_macros::doc_include!("docs/dispatch.md")]
-#![doc = fp_macros::doc_include!("docs/zero-cost.md")]
-#![doc = fp_macros::doc_include!("docs/pointer-abstraction.md")]
-#![doc = fp_macros::doc_include!("docs/lazy-evaluation.md")]
-#![doc = fp_macros::doc_include!("docs/parallelism.md")]
+//!
+//! **Higher-Kinded Types:** The library encodes HKTs using lightweight higher-kinded polymorphism
+//! (the "Brand" pattern). Each type constructor has a zero-sized brand type (e.g., `OptionBrand`)
+//! that implements `Kind` traits mapping brands back to concrete types.
+//! See [Higher-Kinded Types][crate::docs::hkt].
+//!
+//! **Brand Inference:** `InferableBrand` traits provide the reverse mapping (concrete type -> brand),
+//! letting the compiler infer brands automatically. `trait_kind!` and `impl_kind!` generate both
+//! mappings. See [Brand Inference][crate::docs::brand_inference].
+//!
+//! **Val/Ref Dispatch:** Each free function routes to either a by-value or by-reference trait method
+//! based on the closure's argument type (or container ownership for closureless operations). Dispatch
+//! and brand inference compose through the shared `FA` type parameter.
+//! See [Val/Ref Dispatch][crate::docs::dispatch].
+//!
+//! **Zero-Cost Abstractions:** Core operations use uncurried semantics with `impl Fn` for static
+//! dispatch and zero heap allocation. Dynamic dispatch (`dyn Fn`) is reserved for cases where
+//! functions must be stored as data.
+//! See [Zero-Cost Abstractions][crate::docs::zero_cost].
+//!
+//! **Lazy Evaluation:** A granular hierarchy of lazy types (`Thunk`, `Trampoline`, `Lazy`) lets you
+//! choose trade-offs between stack safety, memoization, lifetimes, and thread safety. Each has a
+//! fallible `Try*` counterpart.
+//! See [Lazy Evaluation][crate::docs::lazy_evaluation].
+//!
+//! **Thread Safety & Parallelism:** A parallel trait hierarchy (`ParFunctor`, `ParFoldable`, etc.)
+//! mirrors the sequential one. When the `rayon` feature is enabled, `par_*` functions use true
+//! parallel execution.
+//! See [Thread Safety and Parallelism][crate::docs::parallelism].
+//!
+//! ## Documentation
+//!
+//! - [Features & Type Class Hierarchy][crate::docs::features]
+//! - [Higher-Kinded Types][crate::docs::hkt]
+//! - [Brand Inference][crate::docs::brand_inference]
+//! - [Val/Ref Dispatch][crate::docs::dispatch]
+//! - [Zero-Cost Abstractions][crate::docs::zero_cost]
+//! - [Pointer Abstraction][crate::docs::pointer_abstraction]
+//! - [Lazy Evaluation][crate::docs::lazy_evaluation]
+//! - [Coyoneda Implementations][crate::docs::coyoneda]
+//! - [Thread Safety & Parallelism][crate::docs::parallelism]
+//! - [Limitations and Workarounds][crate::docs::limitations_and_workarounds]
+//! - [Project Structure][crate::docs::project_structure]
+//! - [Architecture & Design][crate::docs::architecture]
+//! - [Optics Analysis][crate::docs::optics_analysis]
+//! - [Profunctor Analysis][crate::docs::profunctor_analysis]
+//! - [Std Library Coverage][crate::docs::std_coverage_checklist]
 //!
 //! ## Crate Features
 //!

--- a/fp-library/src/lib.rs
+++ b/fp-library/src/lib.rs
@@ -72,16 +72,16 @@
 //! });
 //! assert_eq!(result, vec![11, 21, 12, 22]);
 //! ```
-#![doc = include_str!("../docs/features.md")]
+#![doc = fp_macros::doc_include!("docs/features.md")]
 //!
 //! ## How it Works
-#![doc = include_str!("../docs/hkt.md")]
-#![doc = include_str!("../docs/brand-inference.md")]
-#![doc = include_str!("../docs/dispatch.md")]
-#![doc = include_str!("../docs/zero-cost.md")]
-#![doc = include_str!("../docs/pointer-abstraction.md")]
-#![doc = include_str!("../docs/lazy-evaluation.md")]
-#![doc = include_str!("../docs/parallelism.md")]
+#![doc = fp_macros::doc_include!("docs/hkt.md")]
+#![doc = fp_macros::doc_include!("docs/brand-inference.md")]
+#![doc = fp_macros::doc_include!("docs/dispatch.md")]
+#![doc = fp_macros::doc_include!("docs/zero-cost.md")]
+#![doc = fp_macros::doc_include!("docs/pointer-abstraction.md")]
+#![doc = fp_macros::doc_include!("docs/lazy-evaluation.md")]
+#![doc = fp_macros::doc_include!("docs/parallelism.md")]
 //!
 //! ## Crate Features
 //!
@@ -94,6 +94,7 @@ extern crate fp_macros;
 pub mod brands;
 pub mod classes;
 pub mod dispatch;
+pub mod docs;
 pub mod functions;
 pub mod kinds;
 pub mod types;

--- a/fp-macros/CHANGELOG.md
+++ b/fp-macros/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-04-15
+
+### Added
+
+- **`doc_include!` proc macro**: Reads a markdown file at compile time and rewrites same-directory `.md` links to rustdoc intra-doc links (`[text][crate::docs::module_name]`). Enables cross-document links in rendered rustdoc output.
+
+### Fixed
+
+- **Explicit dispatch HM signatures**: `is_inferable_brand_param` renamed to `is_dispatch_container_param` and extended to recognize `*Dispatch` bounds (not just `InferableBrand_*`). This fixes explicit closureless dispatch functions (compact, separate, alt, join) whose HM signatures showed raw `FA` instead of branded container types. Also handles `impl *Dispatch` params for closureless explicit functions (e.g., `explicit::join`).
+
+### Changed
+
+- **`trait_kind!`/`impl_kind!` documentation**: Updated to mention `InferableBrand` trait generation.
+
 ## [0.7.0] - 2026-04-14
 
 ### Added

--- a/fp-macros/Cargo.toml
+++ b/fp-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fp-macros"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 description = "Procedural macros for generating and working with Higher-Kinded Type (HKT) traits in the fp-library crate."
 repository = "https://github.com/nothingnesses/rust-fp-library"

--- a/fp-macros/src/documentation.rs
+++ b/fp-macros/src/documentation.rs
@@ -6,6 +6,7 @@
 //! - #[document_type_parameters] - Type parameter documentation
 //! - #[document_module] - Module-level orchestration
 
+pub mod doc_include;
 pub mod document_examples;
 pub mod document_module;
 pub mod document_parameters;
@@ -16,6 +17,7 @@ pub mod generation;
 pub mod templates;
 
 pub use {
+	doc_include::doc_include_worker,
 	document_examples::document_examples_worker,
 	document_module::document_module_worker,
 	document_parameters::document_parameters_worker,

--- a/fp-macros/src/documentation/doc_include.rs
+++ b/fp-macros/src/documentation/doc_include.rs
@@ -1,0 +1,190 @@
+//! `doc_include!` macro for including markdown files with link rewriting.
+//!
+//! Reads a markdown file relative to `CARGO_MANIFEST_DIR` and rewrites
+//! relative `.md` links to rustdoc intra-doc links pointing at
+//! `crate::docs::module_name` submodules.
+
+use {
+	crate::core::constants::configuration,
+	proc_macro2::TokenStream,
+	quote::quote,
+};
+
+/// Worker function for the `doc_include!` proc macro.
+///
+/// Parses a string literal file path, reads the file relative to
+/// `CARGO_MANIFEST_DIR`, rewrites same-directory `.md` links to
+/// intra-doc links, and returns a string literal token.
+pub fn doc_include_worker(input: TokenStream) -> Result<TokenStream, syn::Error> {
+	let lit: syn::LitStr = syn::parse2(input)?;
+	let rel_path = lit.value();
+
+	#[expect(clippy::expect_used, reason = "CARGO_MANIFEST_DIR is always set by Cargo")]
+	let manifest_dir =
+		std::env::var(configuration::CARGO_MANIFEST_DIR).expect("CARGO_MANIFEST_DIR not set");
+
+	let full_path = std::path::Path::new(&manifest_dir).join(&rel_path);
+	let content = std::fs::read_to_string(&full_path).map_err(|e| {
+		syn::Error::new_spanned(&lit, format!("failed to read {}: {e}", full_path.display()))
+	})?;
+
+	let rewritten = rewrite_md_links(&content);
+	Ok(quote!(#rewritten))
+}
+
+/// Rewrite same-directory `.md` links to rustdoc intra-doc links.
+///
+/// Transforms `[text](./foo-bar.md)` and `[text](foo-bar.md)` into
+/// `[text][crate::docs::foo_bar]`. Links with path separators (e.g.,
+/// `../` or subdirectories) are left unchanged.
+fn rewrite_md_links(content: &str) -> String {
+	let mut result = String::with_capacity(content.len());
+	let mut rest = content;
+
+	while let Some(open_pos) = rest.find('[') {
+		// Push everything before the `[`
+		result.push_str(&rest[.. open_pos]);
+		let after_open = &rest[open_pos + 1 ..];
+
+		// Find matching `]` (no nesting support needed for doc links)
+		if let Some(close_offset) = after_open.find(']') {
+			let link_text = &after_open[.. close_offset];
+			let after_close = &after_open[close_offset + 1 ..];
+
+			// Check if `(` follows immediately
+			if let Some(url_content) = after_close.strip_prefix('(') {
+				// Find closing `)` (simple, no nested parens needed for .md URLs)
+				if let Some(paren_end) = url_content.find(')') {
+					let url = &url_content[.. paren_end];
+
+					if let Some(module_name) = md_link_to_module(url) {
+						// Rewrite to intra-doc link
+						result.push('[');
+						result.push_str(link_text);
+						result.push_str("][crate::docs::");
+						result.push_str(&module_name);
+						result.push(']');
+						rest = &url_content[paren_end + 1 ..];
+						continue;
+					}
+				}
+			}
+		}
+
+		// Not a rewritable link; push the `[` and advance past it
+		result.push('[');
+		rest = after_open;
+	}
+
+	// Push any remaining content after the last `[`
+	result.push_str(rest);
+	result
+}
+
+/// If a URL is a same-directory `.md` link, return the corresponding
+/// module name. Returns `None` for non-local links.
+///
+/// Accepts `./foo-bar.md` or `foo-bar.md` (no path separators beyond
+/// the optional `./` prefix). Hyphens are converted to underscores.
+fn md_link_to_module(url: &str) -> Option<String> {
+	let stripped = url.strip_prefix("./").unwrap_or(url);
+
+	// Must end with .md
+	let stem = stripped.strip_suffix(".md")?;
+
+	// Must not contain path separators (no subdirectories or parent refs)
+	if stem.contains('/') || stem.contains('\\') {
+		return None;
+	}
+
+	// Must not be empty
+	if stem.is_empty() {
+		return None;
+	}
+
+	// Convert hyphens to underscores for a valid Rust module name
+	Some(stem.replace('-', "_"))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_md_link_to_module_with_dot_slash() {
+		assert_eq!(md_link_to_module("./zero-cost.md"), Some("zero_cost".into()));
+	}
+
+	#[test]
+	fn test_md_link_to_module_without_prefix() {
+		assert_eq!(md_link_to_module("hkt.md"), Some("hkt".into()));
+	}
+
+	#[test]
+	fn test_md_link_to_module_with_hyphens() {
+		assert_eq!(md_link_to_module("./brand-inference.md"), Some("brand_inference".into()));
+	}
+
+	#[test]
+	fn test_md_link_to_module_parent_path_ignored() {
+		assert_eq!(md_link_to_module("../src/foo.md"), None);
+	}
+
+	#[test]
+	fn test_md_link_to_module_subdirectory_ignored() {
+		assert_eq!(md_link_to_module("./sub/foo.md"), None);
+	}
+
+	#[test]
+	fn test_md_link_to_module_non_md_ignored() {
+		assert_eq!(md_link_to_module("./foo.rs"), None);
+	}
+
+	#[test]
+	fn test_rewrite_simple_link() {
+		let input = "See [Zero-Cost](./zero-cost.md) for details.";
+		let expected = "See [Zero-Cost][crate::docs::zero_cost] for details.";
+		assert_eq!(rewrite_md_links(input), expected);
+	}
+
+	#[test]
+	fn test_rewrite_multiple_links() {
+		let input = "See [HKT](./hkt.md) and [Dispatch](./dispatch.md).";
+		let expected = "See [HKT][crate::docs::hkt] and [Dispatch][crate::docs::dispatch].";
+		assert_eq!(rewrite_md_links(input), expected);
+	}
+
+	#[test]
+	fn test_rewrite_leaves_parent_links() {
+		let input = "See [source](../src/foo.rs) for details.";
+		assert_eq!(rewrite_md_links(input), input);
+	}
+
+	#[test]
+	fn test_rewrite_leaves_non_md_links() {
+		let input = "See [docs](https://example.com) for details.";
+		assert_eq!(rewrite_md_links(input), input);
+	}
+
+	#[test]
+	fn test_rewrite_without_dot_slash_prefix() {
+		let input = "See [Optics](optics-analysis.md) for details.";
+		let expected = "See [Optics][crate::docs::optics_analysis] for details.";
+		assert_eq!(rewrite_md_links(input), expected);
+	}
+
+	#[test]
+	fn test_rewrite_preserves_surrounding_text() {
+		let input = "prefix [A](./a.md) middle [B](./b.md) suffix";
+		let expected = "prefix [A][crate::docs::a] middle [B][crate::docs::b] suffix";
+		assert_eq!(rewrite_md_links(input), expected);
+	}
+
+	#[test]
+	fn test_rewrite_inline_link_in_bold() {
+		let input = "**Config:** see [Pointer Abstraction](./pointer-abstraction.md) for how.";
+		let expected =
+			"**Config:** see [Pointer Abstraction][crate::docs::pointer_abstraction] for how.";
+		assert_eq!(rewrite_md_links(input), expected);
+	}
+}

--- a/fp-macros/src/documentation/generation.rs
+++ b/fp-macros/src/documentation/generation.rs
@@ -671,8 +671,60 @@ fn build_synthetic_signature(
 			fn_params.push(closure_param);
 			continue;
 		}
-		// Skip impl Trait params that didn't produce a closure (e.g., placeholder)
-		if matches!(&*pat_type.ty, Type::ImplTrait(_)) {
+		// For closureless dispatch with impl *Dispatch param (e.g., explicit join),
+		// treat the param as a container. Falls through to the container/InferableBrand
+		// logic below by extracting the param name from the impl trait bound.
+		if let Type::ImplTrait(impl_trait) = &*pat_type.ty {
+			// Check if this is an impl *Dispatch bound (closureless container param)
+			let is_dispatch_bound = impl_trait.bounds.iter().any(|b| {
+				if let TypeParamBound::Trait(t) = b {
+					t.path
+						.segments
+						.last()
+						.map(|s| {
+							s.ident
+								.to_string()
+								.ends_with(crate::core::constants::markers::DISPATCH_SUFFIX)
+						})
+						.unwrap_or(false)
+				} else {
+					false
+				}
+			});
+			if is_dispatch_bound && dispatch_info.arrow_type.is_none() {
+				// Closureless dispatch with impl Dispatch param: treat as container.
+				// Use the same fallback chain as InferableBrand-bounded params.
+				use crate::analysis::dispatch::ReturnStructure;
+				let element_types: Option<Vec<String>> = dispatch_info
+					.self_type_elements
+					.clone()
+					.or_else(|| {
+						let elems: Vec<String> = dispatch_info
+							.type_param_order
+							.iter()
+							.filter(|p| {
+								*p != brand_param
+									&& p.len() == 1 && !dispatch_info
+									.secondary_constraints
+									.iter()
+									.any(|(sc, _)| sc == *p)
+							})
+							.cloned()
+							.collect();
+						if elems.is_empty() { None } else { Some(elems) }
+					})
+					.or_else(|| match &dispatch_info.return_structure {
+						ReturnStructure::Applied(args) => Some(args.clone()),
+						_ => None,
+					});
+				if let Some(ref elements) = element_types {
+					let pat = &pat_type.pat;
+					let container_type = build_applied_type(&brand_ident, &kind_ident, elements)?;
+					fn_params.push(parse_quote!(#pat: #container_type));
+					continue;
+				}
+			}
+			// Skip other impl Trait params that didn't produce a closure or container
 			continue;
 		}
 
@@ -721,7 +773,7 @@ fn build_synthetic_signature(
 		// 1. self_type_elements: from the Val impl's self type (e.g., separate, compact)
 		// 2. type_param_order: single-letter element types from the trait definition (e.g., alt)
 		// 3. return structure: from the dispatch method's return type (last resort)
-		if is_inferable_brand_param(&type_str, _original_sig) {
+		if is_dispatch_container_param(&type_str, _original_sig) {
 			use crate::analysis::dispatch::ReturnStructure;
 
 			let element_types: Option<Vec<String>> = dispatch_info
@@ -883,7 +935,7 @@ fn extract_dispatch_trait_args(bound: &TypeParamBound) -> Option<Vec<String>> {
 }
 
 /// Check if a type name is an InferableBrand-bounded param in the signature's where clause.
-fn is_inferable_brand_param(
+fn is_dispatch_container_param(
 	type_name: &str,
 	sig: &syn::Signature,
 ) -> bool {
@@ -901,7 +953,9 @@ fn is_inferable_brand_param(
 								.last()
 								.map(|s| s.ident.to_string())
 								.unwrap_or_default();
-							if name.starts_with("InferableBrand_") {
+							if name.starts_with("InferableBrand_")
+								|| name.ends_with(crate::core::constants::markers::DISPATCH_SUFFIX)
+							{
 								return true;
 							}
 						}

--- a/fp-macros/src/lib.rs
+++ b/fp-macros/src/lib.rs
@@ -34,6 +34,7 @@ use {
 		generate_re_exports_worker,
 	},
 	documentation::{
+		doc_include_worker,
 		document_examples_worker,
 		document_module_worker,
 		document_parameters_worker,
@@ -1444,6 +1445,32 @@ pub fn m_do(input: TokenStream) -> TokenStream {
 pub fn a_do(input: TokenStream) -> TokenStream {
 	let input = parse_macro_input!(input as DoInput);
 	match a_do_worker(input) {
+		Ok(tokens) => tokens.into(),
+		Err(e) => e.to_compile_error().into(),
+	}
+}
+
+/// Includes a markdown file with relative `.md` links rewritten to rustdoc intra-doc links.
+///
+/// This macro reads a markdown file at compile time (relative to `CARGO_MANIFEST_DIR`)
+/// and rewrites same-directory `.md` links to point at `crate::docs::module_name`
+/// submodules, making cross-document links work in rendered rustdoc output.
+///
+/// ### Syntax
+///
+/// ```ignore
+/// #![doc = doc_include!("docs/hkt.md")]
+/// ```
+///
+/// ### Link Rewriting
+///
+/// - `[text](./foo-bar.md)` becomes `[text][crate::docs::foo_bar]`
+/// - `[text](foo-bar.md)` becomes `[text][crate::docs::foo_bar]`
+/// - Links with path separators (`../`, subdirectories) are left unchanged.
+/// - Non-`.md` links are left unchanged.
+#[proc_macro]
+pub fn doc_include(input: TokenStream) -> TokenStream {
+	match doc_include_worker(input.into()) {
 		Ok(tokens) => tokens.into(),
 		Err(e) => e.to_compile_error().into(),
 	}

--- a/fp-macros/src/lib.rs
+++ b/fp-macros/src/lib.rs
@@ -195,9 +195,11 @@ pub fn InferableBrand(input: TokenStream) -> TokenStream {
 	quote!(#name).into()
 }
 
-/// Defines a new `Kind` trait.
+/// Defines a new `Kind` trait and its corresponding `InferableBrand` trait.
 ///
-/// This macro generates a trait definition for a Higher-Kinded Type signature.
+/// This macro generates a trait definition for a Higher-Kinded Type signature,
+/// along with an `InferableBrand` trait that enables automatic Brand inference
+/// in dispatch functions (see [`crate::dispatch`](https://docs.rs/fp-library/latest/fp_library/dispatch/)).
 ///
 /// ### Syntax
 ///
@@ -258,11 +260,12 @@ pub fn trait_kind(input: TokenStream) -> TokenStream {
 	}
 }
 
-/// Implements a `Kind` trait for a brand.
+/// Implements a `Kind` trait and its `InferableBrand` trait for a brand.
 ///
 /// This macro simplifies the implementation of a generated `Kind` trait for a specific
-/// brand type. It infers the correct `Kind` trait to implement based on the signature
-/// of the associated types provided in the block.
+/// brand type, and also generates the `InferableBrand` impl that enables automatic Brand
+/// inference in dispatch functions. It infers the correct `Kind` trait to implement based
+/// on the signature of the associated types provided in the block.
 ///
 /// The signature (names, parameters, and bounds) of the associated types must match
 /// the definition used in [`trait_kind!`] or [`Kind!`] to ensure the correct trait is implemented.


### PR DESCRIPTION
## Summary

- Release fp-library v0.16.1 and fp-macros v0.7.1.
- `doc_include!` proc macro for markdown files with link rewriting to rustdoc intra-doc links.
- `docs` module with 19 submodules for per-document rustdoc pages.
- Fix explicit dispatch HM signatures for closureless functions.
- Crate root docs replaced with concise summaries and links to docs module pages.
- Updated `functions.rs` and `trait_kind!/impl_kind!` documentation.
- `cargo-insta` added to dev shell, CONTRIBUTING.md updated with snapshot test and trybuild instructions.
- Pseudo-code blocks in 6 markdown files marked as `rust,ignore` for correct rustdoc compilation.

## Test plan

- `just verify` passes (fmt, check, clippy, deny, doc, test).
- All cross-document links resolve correctly in rendered rustdoc.
- All 309 fp-macros lib tests pass.