### PR TITLE
ci: replace magic-nix-cache with hestia

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: Mic92/hestia@v2
       - run: cd devenv && nix fmt -- --ci
 
   check:
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: Mic92/hestia@v2
       - run: nix develop ./devenv/ --command just check
 
   clippy:
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: Mic92/hestia@v2
       - run: nix develop ./devenv/ --command just clippy
 
   test:
@@ -48,7 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: Mic92/hestia@v2
       - run: nix develop ./devenv/ --command just test --workspace --all-features
 
   effects-feature-off:
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: Mic92/hestia@v2
       - run: nix develop ./devenv/ --command just effects-feature-off
 
   doc:
@@ -66,7 +66,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: Mic92/hestia@v2
       - run: nix develop ./devenv/ --command just doc
 
   deny:
@@ -75,5 +75,5 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: Mic92/hestia@v2
       - run: nix develop ./devenv/ --command just deny

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -1,0 +1,53 @@
+# Garbage collection for the hestia binary cache.
+#
+# GC must run on the default branch: a PR job's cache scope is read-only
+# towards the default branch and dies with the PR, but the default-branch
+# scope grows forever without GC. This keeps the repository inside
+# GitHub's 10 GB Actions cache quota by deleting paths no branch uses
+# anymore.
+#
+# Adapted from hestia's reference workflow
+# (https://github.com/Mic92/hestia/blob/main/.github/workflows/gc.yml).
+name: Cache GC
+
+# GC handles concurrent pushes, but not a concurrent GC: a second run's
+# repack reads race the first run's post-commit pack deletes. Queue manual
+# runs behind the nightly one instead of overlapping it.
+concurrency:
+  group: hestia-gc
+  cancel-in-progress: false
+
+on:
+  schedule:
+    # Daily, off-peak (UTC).
+    - cron: "23 3 * * *"
+  # Manual runs for debugging and one-off cleanups.
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Plan only; do not repack, touch, or delete anything.
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  gc:
+    runs-on: ubuntu-latest
+    permissions:
+      # REST cache deletes need actions:write.
+      actions: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@main
+      # The action installs the released hestia binary and exports its
+      # path as HESTIA_BIN.
+      - uses: Mic92/hestia@v2
+      - name: Run garbage collection
+        run: |
+          "$HESTIA_BIN" gc \
+            ${{ inputs.dry-run && '--dry-run' || '' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: Mic92/hestia@v2
       - run: nix develop ./devenv/ --command just verify
 
   publish-macros:
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: Mic92/hestia@v2
       - run: nix develop ./devenv/ --command cargo publish -p fp-macros
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: Mic92/hestia@v2
       - run: nix develop ./devenv/ --command cargo publish -p fp-library
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/update-cargo-deps.yml
+++ b/.github/workflows/update-cargo-deps.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: Mic92/hestia@v2
 
       - name: Update Cargo dependencies
         run: nix develop ./devenv/ --command cargo update

--- a/.github/workflows/update-nixpkgs.yml
+++ b/.github/workflows/update-nixpkgs.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: Mic92/hestia@v2
 
       - name: Update nixpkgs input
         run: nix flake update nixpkgs --flake ./devenv/


### PR DESCRIPTION
Every CI job currently logs two failure classes from `magic-nix-cache-action@main`: an authentication error (the action now tries FlakeHub Cache first by default, which needs an OIDC token and a FlakeHub registration we do not have, before falling back to the GitHub Actions cache) and rate-limit degradation (the GitHub-cache half makes one cache API call per store path, our parallel jobs exceed the cache service's rate limit, and the daemon then answers HTTP 418, so caching silently drops out mid-run).

This swaps all 12 uses across the four workflows for [hestia](https://github.com/Mic92/hestia), which targets both problems by design: no FlakeHub component, and build results packed into a few large content-defined-chunked cache entries with far fewer API calls, on the same free GitHub Actions cache with no accounts, secrets, or extra permissions for build jobs. The action is pinned to the `v2` release tag rather than a moving branch.

Also adds `gc.yml` (adapted from hestia's reference workflow): a nightly garbage-collection run on the default branch, needing `actions: write`, that keeps the repository inside GitHub's 10 GB Actions cache quota by deleting paths no branch uses anymore.

Expectations for this PR's own checks: the first run populates the cache, so no speedup yet; the FlakeHub and 418 error lines should be gone from the logs.